### PR TITLE
fix: php website report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 + Tyrrrz/DiscordChatExporter
 + YoutubeExplode
 + Freescale Semiconductor
-+ Сайт php
++ Неофициальный сайт php.su
 + Miro
 + MagicalJellyBean
 + Ajax Systems

--- a/data/csv/toxic-repos.csv
+++ b/data/csv/toxic-repos.csv
@@ -371,7 +371,7 @@ https://www.ribbonsoft.com"
 684,2022-11-11 13:00:00,ip_block,NewTek,newtek.com,Обработка видео. Заблокировали доступ из РФ
 685,2022-11-11 13:00:00,ip_block,Syncfusion,syncfusion.com,UI component suite for developers. Доступ только через VPN https://imgbox.com/MvguElZI
 698,2023-02-07 09:10:00,ip_block,Freescale Semiconductor,http://www.freescale.com/,"Производитель чипов и прошивок к ним. Заблокировали доступ из РФ, через VPN доступен."
-699,2023-02-07 09:10:00,ip_block,Сайт php,https://php.su,"лозунг возле логотипа, блокировка доступа из РФ"
+699,2023-02-07 09:10:00,ip_block,Неофициальный сайт php.su,https://php.su,"лозунг возле логотипа, блокировка доступа из РФ"
 700,2023-02-07 09:10:00,ip_block,Miro,https://miro.com/blog/update-from-miro-team/,"Закрыли офис в РФ; Прекращение всех продаж в РФ и РБ; Приостановка действия лицензий россиян. Бесплатное продление подписок для украинцев.
 https://miro.com/blog/letter-from-miro-support-for-ukraine/"
 701,2023-02-07 09:10:00,ip_block,MagicalJellyBean,https://www.magicaljellybean.com,При заходе с российского IP отображается заглушка с нецензурной надписью

--- a/data/json/toxic-repos.json
+++ b/data/json/toxic-repos.json
@@ -2571,7 +2571,7 @@
         "id": 699,
         "datetime": "2023-02-07 09:10:00",
         "problem_type": "ip_block",
-        "name": "Сайт php",
+        "name": "Неофициальный сайт php.su",
         "commit_link": "https://php.su",
         "description": "лозунг возле логотипа, блокировка доступа из РФ"
     },


### PR DESCRIPTION
Репорт с заголовком «Сайт php» может вводить в заблуждение, так как php.su не является официальным ресурсом. Предлагаю заменить на «Неофициальный сайт php.su».